### PR TITLE
Remove unnecessary autotimeout config

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,14 +95,6 @@ c.UCRSpawner.gpu = 0
 c.UCRSpawner.max_gpu = 2
 ```
 
-### Auto timeout
-
-You can automatically stop running notebook servers which doesn't make any communication with the hub. Set the timeout period.
-
-```python
-c.UCRSpawner.autotimeout = 1800 # in seconds
-```
-
 ### Mesos Slaves
 
 You can get available resources of meso slaves in your handlers, which inherit `BaseHandler` through this spawner.

--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -21,6 +21,5 @@ c.UCRSpawner.disk = 1000
 c.UCRSpawner.max_disk = 5000
 c.UCRSpawner.gpu = 0
 c.UCRSpawner.max_gpu = 0
-c.UCRSpawner.autotimeout = 1800
 c.UCRSpawner.mesos_user = os.environ['MESOS_USER']
 c.UCRSpawner.debug = True

--- a/ucrspawner/ucrspawner.py
+++ b/ucrspawner/ucrspawner.py
@@ -103,11 +103,6 @@ class UCRSpawner(Spawner):
 
     mesos_user = Unicode(None, config=True, allow_none=True)
 
-    autotimeout = Integer(None,
-                          help="Seconds to automatically timeout unused notebook servers",
-                          config=True,
-                          allow_none=True)
-
     hub_ip_connect = Unicode(
         "",
         help="Public IP address of the hub"
@@ -453,18 +448,6 @@ class UCRSpawner(Spawner):
             self.log.error(
                 "No healthy instance for application %s", self.app_id)
             return 2
-
-        if self.autotimeout is not None:
-            tm_diff = datetime.utcnow() - self.user.last_activity
-            self.log.debug("Application %s is inactive for %d sec",
-                           self.app_id, tm_diff.seconds)
-            if tm_diff > timedelta(seconds=self.autotimeout):
-                self.log.info(
-                    "Stopping application %s because it's inactive for more than %d sec",
-                    self.app_id, self.autotimeout)
-                # Do not yield the result of stop here
-                self.stop()
-                return 0
 
         return None
 


### PR DESCRIPTION
`autotimeout` is not necessary in a spawner because JupyterHub can be extended with services.
https://github.com/jupyterhub/jupyterhub/tree/0.8.1/examples/cull-idle